### PR TITLE
feat(db): Soft FK 기반 DB 초기 구조 구축

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-aop")
+    implementation("org.flywaydb:flyway-core")
+    runtimeOnly("org.flywaydb:flyway-mysql")
 
     implementation("org.springframework.kafka:spring-kafka")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4")
@@ -79,7 +81,6 @@ dependencies {
     testImplementation("org.testcontainers:kafka")
     testImplementation("com.redis:testcontainers-redis:2.2.4")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testRuntimeOnly("com.h2database:h2")
 
     testCompileOnly("org.projectlombok:lombok")
     testAnnotationProcessor("org.projectlombok:lombok")

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -1,0 +1,218 @@
+# Database Schema (Soft FK)
+
+> 최종 수정일: 2026-04-01
+
+---
+
+## 1. 목적
+
+- 인증/이벤트 도메인의 초기 스키마를 Flyway 기준으로 관리합니다.
+- 확장성과 온라인 마이그레이션 유연성을 위해 물리적 FK를 두지 않습니다.
+- 대신 논리 FK 규약, 인덱스 강제, orphan 점검 배치를 통해 정합성을 유지합니다.
+
+---
+
+## 2. 스키마 범위
+
+### 2-1. 인증(Auth)
+
+- `members`
+- `auth_identities`
+- `email_verifications`
+- `refresh_tokens`
+
+### 2-2. 이벤트(Event)
+
+- `venues`
+- `events`
+- `event_sessions`
+
+### 2-3. 제외 범위
+
+- `seats`, `section_inventories`, `queue`, `bookings`, `payments` 등 후속 슬라이스 테이블
+
+---
+
+## 3. Soft FK 규약
+
+### 3-1. 기본 원칙
+
+- 물리 FK `CONSTRAINT`는 생성하지 않습니다.
+- 참조 컬럼은 `*_id` 형식을 사용합니다.
+- 참조 컬럼 타입은 대상 PK와 완전히 동일하게 유지합니다.
+- 참조 컬럼에는 인덱스를 반드시 생성합니다.
+
+### 3-2. 논리 FK 매핑
+
+- `auth_identities.member_id -> members.id`
+- `email_verifications.member_id -> members.id`
+- `refresh_tokens.member_id -> members.id`
+- `events.venue_id -> venues.id`
+- `event_sessions.event_id -> events.id`
+
+---
+
+## 4. 삭제 정책
+
+- 기본 삭제는 soft delete(`deleted_at`)를 사용합니다.
+- 사용자/운영자 요청으로 데이터 제거가 필요해도 우선 soft delete로 처리합니다.
+- hard delete가 필요한 경우 orphan 점검 후 제한적으로 수행합니다.
+
+---
+
+## 5. 정합성 점검 배치 기준
+
+아래 쿼리는 운영 배치 또는 점검 잡에서 주기적으로 실행합니다.
+
+```sql
+-- auth_identities orphan
+SELECT ai.id
+FROM auth_identities ai
+LEFT JOIN members m ON m.id = ai.member_id
+WHERE ai.deleted_at IS NULL
+  AND (m.id IS NULL OR m.deleted_at IS NOT NULL);
+
+-- email_verifications orphan
+SELECT ev.id
+FROM email_verifications ev
+LEFT JOIN members m ON m.id = ev.member_id
+WHERE ev.deleted_at IS NULL
+  AND (m.id IS NULL OR m.deleted_at IS NOT NULL);
+
+-- refresh_tokens orphan
+SELECT rt.id
+FROM refresh_tokens rt
+LEFT JOIN members m ON m.id = rt.member_id
+WHERE rt.deleted_at IS NULL
+  AND (m.id IS NULL OR m.deleted_at IS NOT NULL);
+
+-- events orphan
+SELECT e.id
+FROM events e
+LEFT JOIN venues v ON v.id = e.venue_id
+WHERE e.deleted_at IS NULL
+  AND (v.id IS NULL OR v.deleted_at IS NOT NULL);
+
+-- event_sessions orphan
+SELECT es.id
+FROM event_sessions es
+LEFT JOIN events e ON e.id = es.event_id
+WHERE es.deleted_at IS NULL
+  AND (e.id IS NULL OR e.deleted_at IS NOT NULL);
+```
+
+---
+
+## 6. 마이그레이션 원칙
+
+- Flyway 스크립트를 스키마의 단일 기준(Source of Truth)으로 사용합니다.
+- `spring.jpa.hibernate.ddl-auto`는 모든 프로파일에서 `validate`를 사용합니다.
+- 컬럼/인덱스 변경은 Flyway 버전 마이그레이션으로만 반영합니다.
+
+---
+
+## 7. ERD
+
+```mermaid
+erDiagram
+  MEMBERS {
+    BIGINT id PK
+    VARCHAR email UK
+    VARCHAR password_hash
+    VARCHAR name
+    VARCHAR role
+    VARCHAR status
+    BOOLEAN email_verified
+    DATETIME last_login_at
+    DATETIME deleted_at
+    DATETIME created_at
+    DATETIME updated_at
+  }
+
+  AUTH_IDENTITIES {
+    BIGINT id PK
+    BIGINT member_id
+    VARCHAR provider
+    VARCHAR provider_user_id
+    VARCHAR provider_email
+    DATETIME linked_at
+    DATETIME deleted_at
+    DATETIME created_at
+    DATETIME updated_at
+  }
+
+  EMAIL_VERIFICATIONS {
+    BIGINT id PK
+    BIGINT member_id
+    VARCHAR email
+    VARCHAR purpose
+    VARCHAR verification_code
+    DATETIME expires_at
+    DATETIME verified_at
+    DATETIME consumed_at
+    VARCHAR requested_ip
+    DATETIME deleted_at
+    DATETIME created_at
+    DATETIME updated_at
+  }
+
+  REFRESH_TOKENS {
+    BIGINT id PK
+    BIGINT member_id
+    VARCHAR token_hash UK
+    DATETIME issued_at
+    DATETIME expires_at
+    DATETIME revoked_at
+    VARCHAR revoked_reason
+    VARCHAR user_agent
+    VARCHAR ip_address
+    DATETIME deleted_at
+    DATETIME created_at
+    DATETIME updated_at
+  }
+
+  VENUES {
+    BIGINT id PK
+    VARCHAR name
+    VARCHAR address
+    VARCHAR timezone
+    INT capacity
+    DATETIME deleted_at
+    DATETIME created_at
+    DATETIME updated_at
+  }
+
+  EVENTS {
+    BIGINT id PK
+    BIGINT venue_id
+    VARCHAR title
+    TEXT description
+    VARCHAR category
+    VARCHAR thumbnail_url
+    DATETIME booking_open_at
+    VARCHAR booking_status
+    INT cancel_deadline_hours
+    VARCHAR status
+    DATETIME deleted_at
+    DATETIME created_at
+    DATETIME updated_at
+  }
+
+  EVENT_SESSIONS {
+    BIGINT id PK
+    BIGINT event_id
+    DATETIME starts_at
+    DATETIME ends_at
+    VARCHAR booking_status
+    VARCHAR seat_mode
+    DATETIME deleted_at
+    DATETIME created_at
+    DATETIME updated_at
+  }
+
+  MEMBERS ||--o{ AUTH_IDENTITIES : logical_ref
+  MEMBERS ||--o{ EMAIL_VERIFICATIONS : logical_ref
+  MEMBERS ||--o{ REFRESH_TOKENS : logical_ref
+  VENUES ||--o{ EVENTS : logical_ref
+  EVENTS ||--o{ EVENT_SESSIONS : logical_ref
+```

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -166,6 +166,7 @@ com.ticketaca
   - api docs
 - `docs/architecture`
   - 구조와 아키텍처 의사결정
+  - database schema(Soft FK 규약)
 - 이후 필요 시 `docs/adr`, `docs/troubleshooting`, `docs/load-test`를 추가합니다.
 
 ---

--- a/src/main/java/com/ticketaca/auth/domain/AuthIdentity.java
+++ b/src/main/java/com/ticketaca/auth/domain/AuthIdentity.java
@@ -1,0 +1,58 @@
+package com.ticketaca.auth.domain;
+
+import com.ticketaca.global.common.SoftDeleteBaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(
+        name = "auth_identities",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_auth_identities_provider_user", columnNames = {"provider", "provider_user_id"}),
+                @UniqueConstraint(name = "uk_auth_identities_member_provider", columnNames = {"member_id", "provider"})
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AuthIdentity extends SoftDeleteBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private AuthProvider provider;
+
+    @Column(name = "provider_user_id", nullable = false, length = 191)
+    private String providerUserId;
+
+    @Column(name = "provider_email", length = 255)
+    private String providerEmail;
+
+    @Column(name = "linked_at", nullable = false)
+    private LocalDateTime linkedAt;
+
+    public AuthIdentity(Long memberId, AuthProvider provider, String providerUserId, String providerEmail) {
+        this.memberId = memberId;
+        this.provider = provider;
+        this.providerUserId = providerUserId;
+        this.providerEmail = providerEmail;
+        this.linkedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/ticketaca/auth/domain/AuthProvider.java
+++ b/src/main/java/com/ticketaca/auth/domain/AuthProvider.java
@@ -1,0 +1,6 @@
+package com.ticketaca.auth.domain;
+
+public enum AuthProvider {
+    EMAIL,
+    KAKAO
+}

--- a/src/main/java/com/ticketaca/auth/domain/EmailVerification.java
+++ b/src/main/java/com/ticketaca/auth/domain/EmailVerification.java
@@ -1,0 +1,73 @@
+package com.ticketaca.auth.domain;
+
+import com.ticketaca.global.common.SoftDeleteBaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "email_verifications")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailVerification extends SoftDeleteBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false, length = 255)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private EmailVerificationPurpose purpose;
+
+    @Column(name = "verification_code", nullable = false, length = 64)
+    private String verificationCode;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "verified_at")
+    private LocalDateTime verifiedAt;
+
+    @Column(name = "consumed_at")
+    private LocalDateTime consumedAt;
+
+    @Column(name = "requested_ip", length = 45)
+    private String requestedIp;
+
+    public EmailVerification(
+            Long memberId,
+            String email,
+            EmailVerificationPurpose purpose,
+            String verificationCode,
+            LocalDateTime expiresAt,
+            String requestedIp
+    ) {
+        this.memberId = memberId;
+        this.email = email;
+        this.purpose = purpose;
+        this.verificationCode = verificationCode;
+        this.expiresAt = expiresAt;
+        this.requestedIp = requestedIp;
+    }
+
+    public void markVerified(LocalDateTime verifiedAt) {
+        this.verifiedAt = verifiedAt;
+        this.consumedAt = verifiedAt;
+    }
+}

--- a/src/main/java/com/ticketaca/auth/domain/EmailVerificationPurpose.java
+++ b/src/main/java/com/ticketaca/auth/domain/EmailVerificationPurpose.java
@@ -1,0 +1,6 @@
+package com.ticketaca.auth.domain;
+
+public enum EmailVerificationPurpose {
+    SIGNUP,
+    PASSWORD_RESET
+}

--- a/src/main/java/com/ticketaca/auth/domain/Member.java
+++ b/src/main/java/com/ticketaca/auth/domain/Member.java
@@ -1,0 +1,74 @@
+package com.ticketaca.auth.domain;
+
+import com.ticketaca.global.common.SoftDeleteBaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(
+        name = "members",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_members_email", columnNames = "email")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends SoftDeleteBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 255)
+    private String email;
+
+    @Column(name = "password_hash", length = 255)
+    private String passwordHash;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private MemberRole role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private MemberStatus status;
+
+    @Column(name = "email_verified", nullable = false)
+    private boolean emailVerified;
+
+    @Column(name = "last_login_at")
+    private LocalDateTime lastLoginAt;
+
+    public Member(String email, String passwordHash, String name, MemberRole role, MemberStatus status) {
+        this.email = email;
+        this.passwordHash = passwordHash;
+        this.name = name;
+        this.role = role;
+        this.status = status;
+        this.emailVerified = false;
+    }
+
+    public void verifyEmail() {
+        this.emailVerified = true;
+        this.status = MemberStatus.ACTIVE;
+    }
+
+    public void updateLastLoginAt(LocalDateTime lastLoginAt) {
+        this.lastLoginAt = lastLoginAt;
+    }
+}

--- a/src/main/java/com/ticketaca/auth/domain/MemberRole.java
+++ b/src/main/java/com/ticketaca/auth/domain/MemberRole.java
@@ -1,0 +1,6 @@
+package com.ticketaca.auth.domain;
+
+public enum MemberRole {
+    MEMBER,
+    ADMIN
+}

--- a/src/main/java/com/ticketaca/auth/domain/MemberStatus.java
+++ b/src/main/java/com/ticketaca/auth/domain/MemberStatus.java
@@ -1,0 +1,7 @@
+package com.ticketaca.auth.domain;
+
+public enum MemberStatus {
+    PENDING,
+    ACTIVE,
+    SUSPENDED
+}

--- a/src/main/java/com/ticketaca/auth/domain/RefreshToken.java
+++ b/src/main/java/com/ticketaca/auth/domain/RefreshToken.java
@@ -1,0 +1,76 @@
+package com.ticketaca.auth.domain;
+
+import com.ticketaca.global.common.SoftDeleteBaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(
+        name = "refresh_tokens",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_refresh_tokens_token_hash", columnNames = "token_hash")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken extends SoftDeleteBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "token_hash", nullable = false, length = 255)
+    private String tokenHash;
+
+    @Column(name = "issued_at", nullable = false)
+    private LocalDateTime issuedAt;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "revoked_at")
+    private LocalDateTime revokedAt;
+
+    @Column(name = "revoked_reason", length = 100)
+    private String revokedReason;
+
+    @Column(name = "user_agent", length = 255)
+    private String userAgent;
+
+    @Column(name = "ip_address", length = 45)
+    private String ipAddress;
+
+    public RefreshToken(
+            Long memberId,
+            String tokenHash,
+            LocalDateTime issuedAt,
+            LocalDateTime expiresAt,
+            String userAgent,
+            String ipAddress
+    ) {
+        this.memberId = memberId;
+        this.tokenHash = tokenHash;
+        this.issuedAt = issuedAt;
+        this.expiresAt = expiresAt;
+        this.userAgent = userAgent;
+        this.ipAddress = ipAddress;
+    }
+
+    public void revoke(String revokedReason, LocalDateTime revokedAt) {
+        this.revokedReason = revokedReason;
+        this.revokedAt = revokedAt;
+    }
+}

--- a/src/main/java/com/ticketaca/auth/repository/AuthIdentityRepository.java
+++ b/src/main/java/com/ticketaca/auth/repository/AuthIdentityRepository.java
@@ -1,0 +1,14 @@
+package com.ticketaca.auth.repository;
+
+import com.ticketaca.auth.domain.AuthIdentity;
+import com.ticketaca.auth.domain.AuthProvider;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AuthIdentityRepository extends JpaRepository<AuthIdentity, Long> {
+
+    Optional<AuthIdentity> findByProviderAndProviderUserIdAndDeletedAtIsNull(AuthProvider provider, String providerUserId);
+
+    boolean existsByMemberIdAndProviderAndDeletedAtIsNull(Long memberId, AuthProvider provider);
+}

--- a/src/main/java/com/ticketaca/auth/repository/EmailVerificationRepository.java
+++ b/src/main/java/com/ticketaca/auth/repository/EmailVerificationRepository.java
@@ -1,0 +1,17 @@
+package com.ticketaca.auth.repository;
+
+import com.ticketaca.auth.domain.EmailVerification;
+import com.ticketaca.auth.domain.EmailVerificationPurpose;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
+
+    Optional<EmailVerification> findTopByEmailAndPurposeAndConsumedAtIsNullAndExpiresAtAfterOrderByCreatedAtDesc(
+            String email,
+            EmailVerificationPurpose purpose,
+            LocalDateTime now
+    );
+}

--- a/src/main/java/com/ticketaca/auth/repository/MemberRepository.java
+++ b/src/main/java/com/ticketaca/auth/repository/MemberRepository.java
@@ -1,0 +1,11 @@
+package com.ticketaca.auth.repository;
+
+import com.ticketaca.auth.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmailAndDeletedAtIsNull(String email);
+}

--- a/src/main/java/com/ticketaca/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/ticketaca/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,14 @@
+package com.ticketaca.auth.repository;
+
+import com.ticketaca.auth.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByTokenHashAndDeletedAtIsNull(String tokenHash);
+
+    long deleteByMemberIdAndExpiresAtBefore(Long memberId, LocalDateTime now);
+}

--- a/src/main/java/com/ticketaca/event/domain/BookingStatus.java
+++ b/src/main/java/com/ticketaca/event/domain/BookingStatus.java
@@ -1,0 +1,8 @@
+package com.ticketaca.event.domain;
+
+public enum BookingStatus {
+    UPCOMING,
+    BOOKING_OPEN,
+    SOLD_OUT,
+    CLOSED
+}

--- a/src/main/java/com/ticketaca/event/domain/Event.java
+++ b/src/main/java/com/ticketaca/event/domain/Event.java
@@ -1,0 +1,79 @@
+package com.ticketaca.event.domain;
+
+import com.ticketaca.global.common.SoftDeleteBaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "events")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Event extends SoftDeleteBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "venue_id", nullable = false)
+    private Long venueId;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private EventCategory category;
+
+    @Column(name = "thumbnail_url", length = 500)
+    private String thumbnailUrl;
+
+    @Column(name = "booking_open_at", nullable = false)
+    private LocalDateTime bookingOpenAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "booking_status", nullable = false, length = 20)
+    private BookingStatus bookingStatus;
+
+    @Column(name = "cancel_deadline_hours", nullable = false)
+    private int cancelDeadlineHours;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private EventStatus status;
+
+    public Event(
+            Long venueId,
+            String title,
+            String description,
+            EventCategory category,
+            String thumbnailUrl,
+            LocalDateTime bookingOpenAt,
+            BookingStatus bookingStatus,
+            int cancelDeadlineHours,
+            EventStatus status
+    ) {
+        this.venueId = venueId;
+        this.title = title;
+        this.description = description;
+        this.category = category;
+        this.thumbnailUrl = thumbnailUrl;
+        this.bookingOpenAt = bookingOpenAt;
+        this.bookingStatus = bookingStatus;
+        this.cancelDeadlineHours = cancelDeadlineHours;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/ticketaca/event/domain/EventCategory.java
+++ b/src/main/java/com/ticketaca/event/domain/EventCategory.java
@@ -1,0 +1,8 @@
+package com.ticketaca.event.domain;
+
+public enum EventCategory {
+    CONCERT,
+    MUSICAL,
+    SPORTS,
+    EXHIBITION
+}

--- a/src/main/java/com/ticketaca/event/domain/EventSession.java
+++ b/src/main/java/com/ticketaca/event/domain/EventSession.java
@@ -1,0 +1,64 @@
+package com.ticketaca.event.domain;
+
+import com.ticketaca.global.common.SoftDeleteBaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(
+        name = "event_sessions",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_event_sessions_event_starts_at", columnNames = {"event_id", "starts_at"})
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EventSession extends SoftDeleteBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "event_id", nullable = false)
+    private Long eventId;
+
+    @Column(name = "starts_at", nullable = false)
+    private LocalDateTime startsAt;
+
+    @Column(name = "ends_at", nullable = false)
+    private LocalDateTime endsAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "booking_status", nullable = false, length = 20)
+    private BookingStatus bookingStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "seat_mode", nullable = false, length = 20)
+    private SeatMode seatMode;
+
+    public EventSession(
+            Long eventId,
+            LocalDateTime startsAt,
+            LocalDateTime endsAt,
+            BookingStatus bookingStatus,
+            SeatMode seatMode
+    ) {
+        this.eventId = eventId;
+        this.startsAt = startsAt;
+        this.endsAt = endsAt;
+        this.bookingStatus = bookingStatus;
+        this.seatMode = seatMode;
+    }
+}

--- a/src/main/java/com/ticketaca/event/domain/EventStatus.java
+++ b/src/main/java/com/ticketaca/event/domain/EventStatus.java
@@ -1,0 +1,7 @@
+package com.ticketaca.event.domain;
+
+public enum EventStatus {
+    ACTIVE,
+    INACTIVE,
+    ARCHIVED
+}

--- a/src/main/java/com/ticketaca/event/domain/SeatMode.java
+++ b/src/main/java/com/ticketaca/event/domain/SeatMode.java
@@ -1,0 +1,6 @@
+package com.ticketaca.event.domain;
+
+public enum SeatMode {
+    ASSIGNED,
+    GENERAL
+}

--- a/src/main/java/com/ticketaca/event/domain/Venue.java
+++ b/src/main/java/com/ticketaca/event/domain/Venue.java
@@ -1,0 +1,42 @@
+package com.ticketaca.event.domain;
+
+import com.ticketaca.global.common.SoftDeleteBaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "venues")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Venue extends SoftDeleteBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 150)
+    private String name;
+
+    @Column(nullable = false, length = 255)
+    private String address;
+
+    @Column(nullable = false, length = 50)
+    private String timezone;
+
+    @Column
+    private Integer capacity;
+
+    public Venue(String name, String address, String timezone, Integer capacity) {
+        this.name = name;
+        this.address = address;
+        this.timezone = timezone;
+        this.capacity = capacity;
+    }
+}

--- a/src/main/java/com/ticketaca/event/repository/EventRepository.java
+++ b/src/main/java/com/ticketaca/event/repository/EventRepository.java
@@ -1,0 +1,12 @@
+package com.ticketaca.event.repository;
+
+import com.ticketaca.event.domain.Event;
+import com.ticketaca.event.domain.EventCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+
+    List<Event> findByCategoryAndDeletedAtIsNull(EventCategory category);
+}

--- a/src/main/java/com/ticketaca/event/repository/EventSessionRepository.java
+++ b/src/main/java/com/ticketaca/event/repository/EventSessionRepository.java
@@ -1,0 +1,16 @@
+package com.ticketaca.event.repository;
+
+import com.ticketaca.event.domain.EventSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface EventSessionRepository extends JpaRepository<EventSession, Long> {
+
+    List<EventSession> findByEventIdAndStartsAtBetweenAndDeletedAtIsNull(
+            Long eventId,
+            LocalDateTime from,
+            LocalDateTime to
+    );
+}

--- a/src/main/java/com/ticketaca/event/repository/VenueRepository.java
+++ b/src/main/java/com/ticketaca/event/repository/VenueRepository.java
@@ -1,0 +1,7 @@
+package com.ticketaca.event.repository;
+
+import com.ticketaca.event.domain.Venue;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VenueRepository extends JpaRepository<Venue, Long> {
+}

--- a/src/main/java/com/ticketaca/global/common/SoftDeleteBaseEntity.java
+++ b/src/main/java/com/ticketaca/global/common/SoftDeleteBaseEntity.java
@@ -1,0 +1,23 @@
+package com.ticketaca.global.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+public abstract class SoftDeleteBaseEntity extends BaseEntity {
+
+    @Column
+    private LocalDateTime deletedAt;
+
+    public void softDelete(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
+
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,7 +13,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true
@@ -36,6 +36,9 @@ spring:
     bootstrap-servers: localhost:9092
     consumer:
       group-id: ticketaca-group
+
+  flyway:
+    enabled: true
 
 # Zipkin
 management:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -38,6 +38,9 @@ spring:
     consumer:
       group-id: ticketaca-group
 
+  flyway:
+    enabled: true
+
 management:
   tracing:
     sampling:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,9 @@ spring:
     active: local
   application:
     name: ticketaca
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
   lifecycle:
     timeout-per-shutdown-phase: 30s
 

--- a/src/main/resources/db/migration/V1__init_auth_event.sql
+++ b/src/main/resources/db/migration/V1__init_auth_event.sql
@@ -1,0 +1,128 @@
+CREATE TABLE members (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    email VARCHAR(255) NOT NULL,
+    password_hash VARCHAR(255) NULL,
+    name VARCHAR(100) NOT NULL,
+    role VARCHAR(20) NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    email_verified BOOLEAN NOT NULL DEFAULT FALSE,
+    last_login_at DATETIME NULL,
+    deleted_at DATETIME NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_members_email (email),
+    KEY idx_members_status (status),
+    KEY idx_members_deleted_at (deleted_at)
+);
+
+CREATE TABLE auth_identities (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    member_id BIGINT NOT NULL,
+    provider VARCHAR(20) NOT NULL,
+    provider_user_id VARCHAR(191) NOT NULL,
+    provider_email VARCHAR(255) NULL,
+    linked_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at DATETIME NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_auth_identities_provider_user (provider, provider_user_id),
+    UNIQUE KEY uk_auth_identities_member_provider (member_id, provider),
+    KEY idx_auth_identities_member_id (member_id),
+    KEY idx_auth_identities_deleted_at (deleted_at)
+);
+
+CREATE TABLE email_verifications (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    member_id BIGINT NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    purpose VARCHAR(20) NOT NULL,
+    verification_code VARCHAR(64) NOT NULL,
+    expires_at DATETIME NOT NULL,
+    verified_at DATETIME NULL,
+    consumed_at DATETIME NULL,
+    requested_ip VARCHAR(45) NULL,
+    deleted_at DATETIME NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    KEY idx_email_verifications_member_id (member_id),
+    KEY idx_email_verifications_email_purpose (email, purpose),
+    KEY idx_email_verifications_expires_at (expires_at),
+    KEY idx_email_verifications_deleted_at (deleted_at)
+);
+
+CREATE TABLE refresh_tokens (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    member_id BIGINT NOT NULL,
+    token_hash VARCHAR(255) NOT NULL,
+    issued_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at DATETIME NOT NULL,
+    revoked_at DATETIME NULL,
+    revoked_reason VARCHAR(100) NULL,
+    user_agent VARCHAR(255) NULL,
+    ip_address VARCHAR(45) NULL,
+    deleted_at DATETIME NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_refresh_tokens_token_hash (token_hash),
+    KEY idx_refresh_tokens_member_id (member_id),
+    KEY idx_refresh_tokens_expires_at (expires_at),
+    KEY idx_refresh_tokens_deleted_at (deleted_at)
+);
+
+CREATE TABLE venues (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(150) NOT NULL,
+    address VARCHAR(255) NOT NULL,
+    timezone VARCHAR(50) NOT NULL DEFAULT 'Asia/Seoul',
+    capacity INT NULL,
+    deleted_at DATETIME NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    KEY idx_venues_name (name),
+    KEY idx_venues_deleted_at (deleted_at)
+);
+
+CREATE TABLE events (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    venue_id BIGINT NOT NULL,
+    title VARCHAR(200) NOT NULL,
+    description TEXT NULL,
+    category VARCHAR(30) NOT NULL,
+    thumbnail_url VARCHAR(500) NULL,
+    booking_open_at DATETIME NOT NULL,
+    booking_status VARCHAR(20) NOT NULL,
+    cancel_deadline_hours INT NOT NULL DEFAULT 24,
+    status VARCHAR(20) NOT NULL,
+    deleted_at DATETIME NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    KEY idx_events_venue_id (venue_id),
+    KEY idx_events_category (category),
+    KEY idx_events_booking_open_at (booking_open_at),
+    KEY idx_events_status (status),
+    KEY idx_events_deleted_at (deleted_at)
+);
+
+CREATE TABLE event_sessions (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    event_id BIGINT NOT NULL,
+    starts_at DATETIME NOT NULL,
+    ends_at DATETIME NOT NULL,
+    booking_status VARCHAR(20) NOT NULL,
+    seat_mode VARCHAR(20) NOT NULL,
+    deleted_at DATETIME NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_event_sessions_event_starts_at (event_id, starts_at),
+    KEY idx_event_sessions_event_id (event_id),
+    KEY idx_event_sessions_starts_at (starts_at),
+    KEY idx_event_sessions_booking_status (booking_status),
+    KEY idx_event_sessions_deleted_at (deleted_at)
+);

--- a/src/main/resources/db/verification/orphan-checks.sql
+++ b/src/main/resources/db/verification/orphan-checks.sql
@@ -1,0 +1,36 @@
+-- Soft FK orphan checks (auth/event)
+
+-- auth_identities orphan
+SELECT ai.id
+FROM auth_identities ai
+LEFT JOIN members m ON m.id = ai.member_id
+WHERE ai.deleted_at IS NULL
+  AND (m.id IS NULL OR m.deleted_at IS NOT NULL);
+
+-- email_verifications orphan
+SELECT ev.id
+FROM email_verifications ev
+LEFT JOIN members m ON m.id = ev.member_id
+WHERE ev.deleted_at IS NULL
+  AND (m.id IS NULL OR m.deleted_at IS NOT NULL);
+
+-- refresh_tokens orphan
+SELECT rt.id
+FROM refresh_tokens rt
+LEFT JOIN members m ON m.id = rt.member_id
+WHERE rt.deleted_at IS NULL
+  AND (m.id IS NULL OR m.deleted_at IS NOT NULL);
+
+-- events orphan
+SELECT e.id
+FROM events e
+LEFT JOIN venues v ON v.id = e.venue_id
+WHERE e.deleted_at IS NULL
+  AND (v.id IS NULL OR v.deleted_at IS NOT NULL);
+
+-- event_sessions orphan
+SELECT es.id
+FROM event_sessions es
+LEFT JOIN events e ON e.id = es.event_id
+WHERE es.deleted_at IS NULL
+  AND (e.id IS NULL OR e.deleted_at IS NOT NULL);

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,13 +1,12 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:ticketaca;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
+    url: jdbc:tc:mysql:8.0:///ticketaca?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    username: test
+    password: test
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
   jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: validate
     show-sql: true
     properties:
       hibernate:
@@ -16,6 +15,8 @@ spring:
     bootstrap-servers: localhost:9092
     consumer:
       group-id: ticketaca-test-group
+  flyway:
+    enabled: true
 
 management:
   endpoint:


### PR DESCRIPTION
### 🔗 관련 이슈
closes #3

### 📌 작업 내용
인증/이벤트 도메인 초기 스키마를 Soft FK 전략으로 구성.
물리 FK 미적용, 논리 FK 규약 + 인덱스 강제 + orphan 점검 쿼리 기준으로 정합성 유지 방식 반영.
Flyway를 스키마 단일 기준으로 도입하고, 프로파일별 ddl-auto를 validate로 통일.

- Flyway 도입 및 마이그레이션 V1 추가
- 인증/이벤트 테이블 초안 생성 (members, auth_identities, email_verifications, refresh_tokens, venues, events, event_sessions)
- Soft delete 공통 베이스 및 auth/event JPA 엔티티/리포지토리 매핑 추가
- orphan 정합성 점검 SQL 추가
- DB 스키마/ERD 문서 동기화

### 🧑‍💻 작업 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [x] 문서 수정
- [ ] CI/CD 변경

### 📷 관련 이미지
~~~mermaid
erDiagram
  MEMBERS ||--o{ AUTH_IDENTITIES : logical_ref
  MEMBERS ||--o{ EMAIL_VERIFICATIONS : logical_ref
  MEMBERS ||--o{ REFRESH_TOKENS : logical_ref
  VENUES ||--o{ EVENTS : logical_ref
  EVENTS ||--o{ EVENT_SESSIONS : logical_ref
~~~