### PR TITLE
feat(auth): 이메일 인증 기반 인증 API 1차 구현

### DIFF
--- a/docs/spec/api_docs.md
+++ b/docs/spec/api_docs.md
@@ -111,6 +111,18 @@ Request:
 }
 ```
 
+### 3-2-1. 이메일 인증 코드 재전송
+
+`POST /auth/email/verification/resend`
+
+Request:
+
+```json
+{
+  "email": "user@example.com"
+}
+```
+
 ### 3-3. 이메일 로그인
 
 `POST /auth/email/login`
@@ -154,6 +166,18 @@ Request:
 ### 3-5. 토큰 재발급
 
 `POST /auth/token/refresh`
+
+Request:
+
+```json
+{
+  "refreshToken": "jwt-refresh-token"
+}
+```
+
+### 3-6. 로그아웃
+
+`POST /auth/logout`
 
 Request:
 

--- a/src/main/java/com/ticketaca/auth/config/AuthConfig.java
+++ b/src/main/java/com/ticketaca/auth/config/AuthConfig.java
@@ -1,0 +1,9 @@
+package com.ticketaca.auth.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(AuthProperties.class)
+public class AuthConfig {
+}

--- a/src/main/java/com/ticketaca/auth/config/AuthProperties.java
+++ b/src/main/java/com/ticketaca/auth/config/AuthProperties.java
@@ -1,0 +1,22 @@
+package com.ticketaca.auth.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "auth")
+public record AuthProperties(
+        Jwt jwt,
+        EmailVerification emailVerification
+) {
+    public record Jwt(
+            String issuer,
+            String secret,
+            long accessTokenExpiresInSeconds,
+            long refreshTokenExpiresInSeconds
+    ) {
+    }
+
+    public record EmailVerification(
+            long expiresInMinutes
+    ) {
+    }
+}

--- a/src/main/java/com/ticketaca/auth/controller/AuthController.java
+++ b/src/main/java/com/ticketaca/auth/controller/AuthController.java
@@ -1,0 +1,90 @@
+package com.ticketaca.auth.controller;
+
+import com.ticketaca.auth.dto.request.EmailLoginRequest;
+import com.ticketaca.auth.dto.request.EmailSignupRequest;
+import com.ticketaca.auth.dto.request.EmailVerificationRequest;
+import com.ticketaca.auth.dto.request.EmailVerificationResendRequest;
+import com.ticketaca.auth.dto.request.KakaoLoginRequest;
+import com.ticketaca.auth.dto.request.LogoutRequest;
+import com.ticketaca.auth.dto.request.TokenRefreshRequest;
+import com.ticketaca.auth.dto.response.EmailSignupResponse;
+import com.ticketaca.auth.dto.response.EmailVerificationResponse;
+import com.ticketaca.auth.dto.response.KakaoLoginEntrypointResponse;
+import com.ticketaca.auth.dto.response.TokenResponse;
+import com.ticketaca.auth.service.AuthService;
+import com.ticketaca.global.common.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/email/signup")
+    public ResponseEntity<ApiResponse<EmailSignupResponse>> signup(
+            @Valid @RequestBody EmailSignupRequest request,
+            HttpServletRequest httpServletRequest
+    ) {
+        EmailSignupResponse response = authService.signup(request, extractClientIp(httpServletRequest));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    @PostMapping("/email/verify")
+    public ResponseEntity<ApiResponse<EmailVerificationResponse>> verifyEmail(
+            @Valid @RequestBody EmailVerificationRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(authService.verifyEmail(request)));
+    }
+
+    @PostMapping("/email/verification/resend")
+    public ResponseEntity<ApiResponse<Void>> resendVerificationCode(
+            @Valid @RequestBody EmailVerificationResendRequest request,
+            HttpServletRequest httpServletRequest
+    ) {
+        authService.resendVerificationCode(request, extractClientIp(httpServletRequest));
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @PostMapping("/email/login")
+    public ResponseEntity<ApiResponse<TokenResponse>> login(@Valid @RequestBody EmailLoginRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(authService.login(request)));
+    }
+
+    @PostMapping("/token/refresh")
+    public ResponseEntity<ApiResponse<TokenResponse>> refresh(@Valid @RequestBody TokenRefreshRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(authService.refresh(request)));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(@Valid @RequestBody LogoutRequest request) {
+        authService.logout(request);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @PostMapping("/social/kakao")
+    public ResponseEntity<ApiResponse<KakaoLoginEntrypointResponse>> kakaoLogin(
+            @Valid @RequestBody KakaoLoginRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(authService.kakaoEntrypoint(request)));
+    }
+
+    private String extractClientIp(HttpServletRequest request) {
+        String forwardedFor = request.getHeader("X-Forwarded-For");
+        if (forwardedFor == null || forwardedFor.isBlank()) {
+            return request.getRemoteAddr();
+        }
+        return forwardedFor.split(",")[0].trim();
+    }
+}

--- a/src/main/java/com/ticketaca/auth/domain/RefreshToken.java
+++ b/src/main/java/com/ticketaca/auth/domain/RefreshToken.java
@@ -73,4 +73,12 @@ public class RefreshToken extends SoftDeleteBaseEntity {
         this.revokedReason = revokedReason;
         this.revokedAt = revokedAt;
     }
+
+    public boolean isRevoked() {
+        return revokedAt != null;
+    }
+
+    public boolean isExpired(LocalDateTime now) {
+        return expiresAt.isBefore(now);
+    }
 }

--- a/src/main/java/com/ticketaca/auth/dto/request/EmailLoginRequest.java
+++ b/src/main/java/com/ticketaca/auth/dto/request/EmailLoginRequest.java
@@ -1,0 +1,13 @@
+package com.ticketaca.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailLoginRequest(
+        @NotBlank
+        @Email
+        String email,
+        @NotBlank
+        String password
+) {
+}

--- a/src/main/java/com/ticketaca/auth/dto/request/EmailSignupRequest.java
+++ b/src/main/java/com/ticketaca/auth/dto/request/EmailSignupRequest.java
@@ -1,0 +1,22 @@
+package com.ticketaca.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record EmailSignupRequest(
+        @NotBlank
+        @Email
+        String email,
+        @NotBlank
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-={}\\[\\]:;\"'<>,.?/]).{8,64}$",
+                message = "비밀번호는 8~64자, 영문/숫자/특수문자를 포함해야 합니다."
+        )
+        String password,
+        @NotBlank
+        @Size(max = 100)
+        String name
+) {
+}

--- a/src/main/java/com/ticketaca/auth/dto/request/EmailVerificationRequest.java
+++ b/src/main/java/com/ticketaca/auth/dto/request/EmailVerificationRequest.java
@@ -1,0 +1,15 @@
+package com.ticketaca.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record EmailVerificationRequest(
+        @NotBlank
+        @Email
+        String email,
+        @NotBlank
+        @Pattern(regexp = "^\\d{6}$", message = "인증 코드는 6자리 숫자여야 합니다.")
+        String verificationCode
+) {
+}

--- a/src/main/java/com/ticketaca/auth/dto/request/EmailVerificationResendRequest.java
+++ b/src/main/java/com/ticketaca/auth/dto/request/EmailVerificationResendRequest.java
@@ -1,0 +1,11 @@
+package com.ticketaca.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailVerificationResendRequest(
+        @NotBlank
+        @Email
+        String email
+) {
+}

--- a/src/main/java/com/ticketaca/auth/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/com/ticketaca/auth/dto/request/KakaoLoginRequest.java
@@ -1,0 +1,14 @@
+package com.ticketaca.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record KakaoLoginRequest(
+        @NotBlank
+        @Size(max = 500)
+        String authorizationCode,
+        @NotBlank
+        @Size(max = 500)
+        String redirectUri
+) {
+}

--- a/src/main/java/com/ticketaca/auth/dto/request/LogoutRequest.java
+++ b/src/main/java/com/ticketaca/auth/dto/request/LogoutRequest.java
@@ -1,0 +1,9 @@
+package com.ticketaca.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LogoutRequest(
+        @NotBlank
+        String refreshToken
+) {
+}

--- a/src/main/java/com/ticketaca/auth/dto/request/TokenRefreshRequest.java
+++ b/src/main/java/com/ticketaca/auth/dto/request/TokenRefreshRequest.java
@@ -1,0 +1,9 @@
+package com.ticketaca.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TokenRefreshRequest(
+        @NotBlank
+        String refreshToken
+) {
+}

--- a/src/main/java/com/ticketaca/auth/dto/response/EmailSignupResponse.java
+++ b/src/main/java/com/ticketaca/auth/dto/response/EmailSignupResponse.java
@@ -1,0 +1,8 @@
+package com.ticketaca.auth.dto.response;
+
+public record EmailSignupResponse(
+        Long memberId,
+        String email,
+        boolean emailVerified
+) {
+}

--- a/src/main/java/com/ticketaca/auth/dto/response/EmailVerificationResponse.java
+++ b/src/main/java/com/ticketaca/auth/dto/response/EmailVerificationResponse.java
@@ -1,0 +1,7 @@
+package com.ticketaca.auth.dto.response;
+
+public record EmailVerificationResponse(
+        String email,
+        boolean verified
+) {
+}

--- a/src/main/java/com/ticketaca/auth/dto/response/KakaoLoginEntrypointResponse.java
+++ b/src/main/java/com/ticketaca/auth/dto/response/KakaoLoginEntrypointResponse.java
@@ -1,0 +1,7 @@
+package com.ticketaca.auth.dto.response;
+
+public record KakaoLoginEntrypointResponse(
+        String status,
+        String message
+) {
+}

--- a/src/main/java/com/ticketaca/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/ticketaca/auth/dto/response/TokenResponse.java
@@ -1,0 +1,9 @@
+package com.ticketaca.auth.dto.response;
+
+public record TokenResponse(
+        String accessToken,
+        long accessTokenExpiresInSeconds,
+        String refreshToken,
+        long refreshTokenExpiresInSeconds
+) {
+}

--- a/src/main/java/com/ticketaca/auth/repository/EmailVerificationRepository.java
+++ b/src/main/java/com/ticketaca/auth/repository/EmailVerificationRepository.java
@@ -4,14 +4,12 @@ import com.ticketaca.auth.domain.EmailVerification;
 import com.ticketaca.auth.domain.EmailVerificationPurpose;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
 
-    Optional<EmailVerification> findTopByEmailAndPurposeAndConsumedAtIsNullAndExpiresAtAfterOrderByCreatedAtDesc(
+    Optional<EmailVerification> findTopByEmailAndPurposeAndConsumedAtIsNullAndDeletedAtIsNullOrderByCreatedAtDesc(
             String email,
-            EmailVerificationPurpose purpose,
-            LocalDateTime now
+            EmailVerificationPurpose purpose
     );
 }

--- a/src/main/java/com/ticketaca/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/ticketaca/auth/repository/RefreshTokenRepository.java
@@ -10,5 +10,7 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 
     Optional<RefreshToken> findByTokenHashAndDeletedAtIsNull(String tokenHash);
 
+    Optional<RefreshToken> findByTokenHashAndRevokedAtIsNullAndDeletedAtIsNull(String tokenHash);
+
     long deleteByMemberIdAndExpiresAtBefore(Long memberId, LocalDateTime now);
 }

--- a/src/main/java/com/ticketaca/auth/security/JwtTokenProvider.java
+++ b/src/main/java/com/ticketaca/auth/security/JwtTokenProvider.java
@@ -1,0 +1,64 @@
+package com.ticketaca.auth.security;
+
+import com.ticketaca.auth.config.AuthProperties;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+
+@Component
+public class JwtTokenProvider {
+
+    private final AuthProperties authProperties;
+    private final SecretKey secretKey;
+
+    public JwtTokenProvider(AuthProperties authProperties) {
+        this.authProperties = authProperties;
+        this.secretKey = Keys.hmacShaKeyFor(authProperties.jwt().secret().getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String createAccessToken(Long memberId, String email, String role) {
+        Instant now = Instant.now();
+        Instant expiresAt = now.plusSeconds(authProperties.jwt().accessTokenExpiresInSeconds());
+        return Jwts.builder()
+                .subject(String.valueOf(memberId))
+                .issuer(authProperties.jwt().issuer())
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(expiresAt))
+                .claims(Map.of(
+                        "type", "access",
+                        "email", email,
+                        "role", role
+                ))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String createRefreshToken(Long memberId) {
+        Instant now = Instant.now();
+        Instant expiresAt = now.plusSeconds(authProperties.jwt().refreshTokenExpiresInSeconds());
+        return Jwts.builder()
+                .subject(String.valueOf(memberId))
+                .issuer(authProperties.jwt().issuer())
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(expiresAt))
+                .claim("type", "refresh")
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public Jws<Claims> parse(String token) throws JwtException {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token);
+    }
+}

--- a/src/main/java/com/ticketaca/auth/service/AuthService.java
+++ b/src/main/java/com/ticketaca/auth/service/AuthService.java
@@ -1,0 +1,258 @@
+package com.ticketaca.auth.service;
+
+import com.ticketaca.auth.config.AuthProperties;
+import com.ticketaca.auth.domain.AuthIdentity;
+import com.ticketaca.auth.domain.AuthProvider;
+import com.ticketaca.auth.domain.EmailVerification;
+import com.ticketaca.auth.domain.EmailVerificationPurpose;
+import com.ticketaca.auth.domain.Member;
+import com.ticketaca.auth.domain.MemberRole;
+import com.ticketaca.auth.domain.MemberStatus;
+import com.ticketaca.auth.domain.RefreshToken;
+import com.ticketaca.auth.dto.request.EmailLoginRequest;
+import com.ticketaca.auth.dto.request.EmailSignupRequest;
+import com.ticketaca.auth.dto.request.EmailVerificationRequest;
+import com.ticketaca.auth.dto.request.EmailVerificationResendRequest;
+import com.ticketaca.auth.dto.request.KakaoLoginRequest;
+import com.ticketaca.auth.dto.request.LogoutRequest;
+import com.ticketaca.auth.dto.request.TokenRefreshRequest;
+import com.ticketaca.auth.dto.response.EmailSignupResponse;
+import com.ticketaca.auth.dto.response.EmailVerificationResponse;
+import com.ticketaca.auth.dto.response.KakaoLoginEntrypointResponse;
+import com.ticketaca.auth.dto.response.TokenResponse;
+import com.ticketaca.auth.repository.AuthIdentityRepository;
+import com.ticketaca.auth.repository.EmailVerificationRepository;
+import com.ticketaca.auth.repository.MemberRepository;
+import com.ticketaca.auth.repository.RefreshTokenRepository;
+import com.ticketaca.auth.security.JwtTokenProvider;
+import com.ticketaca.global.exception.BusinessException;
+import com.ticketaca.global.exception.ErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.HexFormat;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Service
+public class AuthService {
+
+    private static final String EMAIL_PROVIDER_USER_ID_PREFIX = "email:";
+
+    private final MemberRepository memberRepository;
+    private final AuthIdentityRepository authIdentityRepository;
+    private final EmailVerificationRepository emailVerificationRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthProperties authProperties;
+
+    public AuthService(
+            MemberRepository memberRepository,
+            AuthIdentityRepository authIdentityRepository,
+            EmailVerificationRepository emailVerificationRepository,
+            RefreshTokenRepository refreshTokenRepository,
+            PasswordEncoder passwordEncoder,
+            JwtTokenProvider jwtTokenProvider,
+            AuthProperties authProperties
+    ) {
+        this.memberRepository = memberRepository;
+        this.authIdentityRepository = authIdentityRepository;
+        this.emailVerificationRepository = emailVerificationRepository;
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.authProperties = authProperties;
+    }
+
+    @Transactional
+    public EmailSignupResponse signup(EmailSignupRequest request, String requestedIp) {
+        memberRepository.findByEmailAndDeletedAtIsNull(request.email())
+                .ifPresent(existing -> {
+                    throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
+                });
+
+        Member member = memberRepository.save(new Member(
+                request.email(),
+                passwordEncoder.encode(request.password()),
+                request.name(),
+                MemberRole.MEMBER,
+                MemberStatus.PENDING
+        ));
+
+        authIdentityRepository.save(new AuthIdentity(
+                member.getId(),
+                AuthProvider.EMAIL,
+                EMAIL_PROVIDER_USER_ID_PREFIX + request.email(),
+                request.email()
+        ));
+
+        emailVerificationRepository.save(new EmailVerification(
+                member.getId(),
+                request.email(),
+                EmailVerificationPurpose.SIGNUP,
+                generateVerificationCode(),
+                LocalDateTime.now().plusMinutes(authProperties.emailVerification().expiresInMinutes()),
+                requestedIp
+        ));
+
+        return new EmailSignupResponse(member.getId(), member.getEmail(), member.isEmailVerified());
+    }
+
+    @Transactional
+    public EmailVerificationResponse verifyEmail(EmailVerificationRequest request) {
+        EmailVerification verification = emailVerificationRepository
+                .findTopByEmailAndPurposeAndConsumedAtIsNullAndDeletedAtIsNullOrderByCreatedAtDesc(
+                        request.email(),
+                        EmailVerificationPurpose.SIGNUP
+                )
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_VERIFICATION_CODE));
+
+        LocalDateTime now = LocalDateTime.now();
+        if (verification.getExpiresAt().isBefore(now)) {
+            throw new BusinessException(ErrorCode.VERIFICATION_CODE_EXPIRED);
+        }
+        if (!verification.getVerificationCode().equals(request.verificationCode())) {
+            throw new BusinessException(ErrorCode.INVALID_VERIFICATION_CODE);
+        }
+
+        Member member = memberRepository.findById(verification.getMemberId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        verification.markVerified(now);
+        member.verifyEmail();
+        return new EmailVerificationResponse(member.getEmail(), true);
+    }
+
+    @Transactional
+    public void resendVerificationCode(EmailVerificationResendRequest request, String requestedIp) {
+        Member member = memberRepository.findByEmailAndDeletedAtIsNull(request.email())
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+        if (member.isEmailVerified()) {
+            return;
+        }
+
+        emailVerificationRepository.save(new EmailVerification(
+                member.getId(),
+                member.getEmail(),
+                EmailVerificationPurpose.SIGNUP,
+                generateVerificationCode(),
+                LocalDateTime.now().plusMinutes(authProperties.emailVerification().expiresInMinutes()),
+                requestedIp
+        ));
+    }
+
+    @Transactional
+    public TokenResponse login(EmailLoginRequest request) {
+        Member member = memberRepository.findByEmailAndDeletedAtIsNull(request.email())
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_CREDENTIALS));
+        if (!passwordEncoder.matches(request.password(), member.getPasswordHash())) {
+            throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
+        }
+        if (!member.isEmailVerified() || member.getStatus() != MemberStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.EMAIL_NOT_VERIFIED);
+        }
+
+        member.updateLastLoginAt(LocalDateTime.now());
+        return issueTokenPair(member);
+    }
+
+    @Transactional
+    public TokenResponse refresh(TokenRefreshRequest request) {
+        Jws<Claims> claims = parseToken(request.refreshToken());
+        ensureTokenType(claims, "refresh");
+        Long memberId = Long.valueOf(claims.getPayload().getSubject());
+
+        RefreshToken stored = refreshTokenRepository
+                .findByTokenHashAndRevokedAtIsNullAndDeletedAtIsNull(hashToken(request.refreshToken()))
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_TOKEN));
+
+        LocalDateTime now = LocalDateTime.now();
+        if (stored.isExpired(now) || stored.isRevoked()) {
+            throw new BusinessException(ErrorCode.TOKEN_EXPIRED);
+        }
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        stored.revoke("ROTATED", now);
+        return issueTokenPair(member);
+    }
+
+    @Transactional
+    public void logout(LogoutRequest request) {
+        RefreshToken stored = refreshTokenRepository
+                .findByTokenHashAndRevokedAtIsNullAndDeletedAtIsNull(hashToken(request.refreshToken()))
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_TOKEN));
+        stored.revoke("LOGOUT", LocalDateTime.now());
+    }
+
+    @Transactional(readOnly = true)
+    public KakaoLoginEntrypointResponse kakaoEntrypoint(KakaoLoginRequest request) {
+        if (request.authorizationCode().isBlank() || request.redirectUri().isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
+        }
+        return new KakaoLoginEntrypointResponse(
+                "NOT_READY",
+                ErrorCode.KAKAO_LOGIN_NOT_READY.getMessage()
+        );
+    }
+
+    private TokenResponse issueTokenPair(Member member) {
+        String accessToken = jwtTokenProvider.createAccessToken(member.getId(), member.getEmail(), member.getRole().name());
+        String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+
+        refreshTokenRepository.save(new RefreshToken(
+                member.getId(),
+                hashToken(refreshToken),
+                LocalDateTime.now(),
+                LocalDateTime.now().plusSeconds(authProperties.jwt().refreshTokenExpiresInSeconds()),
+                null,
+                null
+        ));
+
+        return new TokenResponse(
+                accessToken,
+                authProperties.jwt().accessTokenExpiresInSeconds(),
+                refreshToken,
+                authProperties.jwt().refreshTokenExpiresInSeconds()
+        );
+    }
+
+    private Jws<Claims> parseToken(String token) {
+        try {
+            return jwtTokenProvider.parse(token);
+        } catch (JwtException e) {
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    private void ensureTokenType(Jws<Claims> claims, String expectedType) {
+        String tokenType = claims.getPayload().get("type", String.class);
+        if (!expectedType.equals(tokenType)) {
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    private String generateVerificationCode() {
+        int value = ThreadLocalRandom.current().nextInt(100000, 1000000);
+        return String.valueOf(value);
+    }
+
+    private String hashToken(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(token.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 algorithm is required", e);
+        }
+    }
+}

--- a/src/main/java/com/ticketaca/global/exception/ErrorCode.java
+++ b/src/main/java/com/ticketaca/global/exception/ErrorCode.java
@@ -8,9 +8,16 @@ public enum ErrorCode {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "로그인이 필요합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "권한이 없습니다."),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "TOKEN_EXPIRED", "토큰이 만료되었습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
     INVALID_ENTRY_TOKEN(HttpStatus.FORBIDDEN, "INVALID_ENTRY_TOKEN", "유효하지 않은 입장 토큰입니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다."),
     INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_PASSWORD_FORMAT", "비밀번호 형식이 올바르지 않습니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS", "이메일 또는 비밀번호가 올바르지 않습니다."),
+    EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN, "EMAIL_NOT_VERIFIED", "이메일 인증이 필요합니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "존재하지 않는 회원입니다."),
+    INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "INVALID_VERIFICATION_CODE", "인증 코드가 올바르지 않습니다."),
+    VERIFICATION_CODE_EXPIRED(HttpStatus.GONE, "VERIFICATION_CODE_EXPIRED", "인증 코드가 만료되었습니다."),
+    KAKAO_LOGIN_NOT_READY(HttpStatus.NOT_IMPLEMENTED, "KAKAO_LOGIN_NOT_READY", "카카오 로그인 연동 준비 중입니다."),
 
     // Event
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "EVENT_NOT_FOUND", "존재하지 않는 이벤트입니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,15 @@ spring:
   lifecycle:
     timeout-per-shutdown-phase: 30s
 
+auth:
+  jwt:
+    issuer: ticketaca
+    secret: ${JWT_SECRET:ticketaca-dev-secret-key-must-be-32bytes}
+    access-token-expires-in-seconds: 900
+    refresh-token-expires-in-seconds: 1209600
+  email-verification:
+    expires-in-minutes: 10
+
 server:
   shutdown: graceful
 


### PR DESCRIPTION
### 🔗 관련 이슈
closes #4

### 📌 작업 내용
이메일 회원가입/이메일 인증/이메일 로그인/토큰 재발급/로그아웃 API 구현.
JWT 발급 및 Refresh Token 해시 저장 기반 토큰 라이프사이클 구현.
카카오 로그인 API 진입점 및 응답 계약 구조 추가.
인증 관련 예외 코드 확장 및 API 명세 문서 동기화.

- /api/v1/auth/email/signup 구현
- /api/v1/auth/email/verify 구현
- /api/v1/auth/email/verification/resend 구현
- /api/v1/auth/email/login 구현
- /api/v1/auth/token/refresh 구현
- /api/v1/auth/logout 구현
- /api/v1/auth/social/kakao 진입점 구현 (연동 준비 상태 응답)
- AuthService, JwtTokenProvider, 요청/응답 DTO 추가
- AuthProperties 기반 JWT/인증 만료 설정 추가
- ErrorCode 인증 오류 코드 보강
- docs/spec/api_docs.md 인증 API 항목 보강

### 🧑‍💻 작업 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [x] 문서 수정
- [ ] CI/CD 변경

### 📷 관련 이미지
없음